### PR TITLE
Update to be compatible with pytorch1

### DIFF
--- a/src/language_models/dictionary_corpus.py
+++ b/src/language_models/dictionary_corpus.py
@@ -18,7 +18,7 @@ class Dictionary(object):
 
         vocab_path = os.path.join(path, 'vocab.txt')
         try:
-            vocab = open(vocab_path).read()
+            vocab = open(vocab_path, encoding="utf8").read()
             self.word2idx = {w: i for i, w in enumerate(vocab.split())}
             self.idx2word = [w for w in vocab.split()]
             self.vocab_file_exists = True
@@ -38,7 +38,7 @@ class Dictionary(object):
         return len(self.idx2word)
 
     def create_vocab(self, path):
-        with open(path, 'r') as f:
+        with open(path, 'r', encoding="utf8") as f:
             for line in f:
                 words = line.split()
                 for word in words:
@@ -57,14 +57,14 @@ def tokenize(dictionary, path):
     """Tokenizes a text file for training or testing to a sequence of indices format
        We assume that training and test data has <eos> symbols """
     assert os.path.exists(path)
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding="utf8") as f:
         ntokens = 0
         for line in f:
             words = line.split()
             ntokens += len(words)
 
     # Tokenize file content
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding="utf8") as f:
         ids = torch.LongTensor(ntokens)
         token = 0
         for line in f:

--- a/src/language_models/main.py
+++ b/src/language_models/main.py
@@ -79,18 +79,19 @@ def evaluate(data_source):
     total_loss = 0
     hidden = model.init_hidden(eval_batch_size)
 
-    for i in range(0, data_source.size(0) - 1, args.bptt):
-        data, targets = get_batch(data_source, i, args.bptt, evaluation=True)
-        #> output has size seq_length x batch_size x vocab_size
-        output, hidden = model(data, hidden)
-        #> output_flat has size num_targets x vocab_size (batches are stacked together)
-        #> ! important, otherwise softmax computation (e.g. with F.softmax()) is incorrect
-        output_flat = output.view(-1, ntokens)
-        #output_candidates_info(output_flat.data, targets.data)
-        total_loss += len(data) * nn.CrossEntropyLoss()(output_flat, targets).data
-        hidden = repackage_hidden(hidden)
+    with torch.no_grad():
+        for i in range(0, data_source.size(0) - 1, args.bptt):
+            data, targets = get_batch(data_source, i, args.bptt)
+            #> output has size seq_length x batch_size x vocab_size
+            output, hidden = model(data, hidden)
+            #> output_flat has size num_targets x vocab_size (batches are stacked together)
+            #> ! important, otherwise softmax computation (e.g. with F.softmax()) is incorrect
+            output_flat = output.view(-1, ntokens)
+            #output_candidates_info(output_flat.data, targets.data)
+            total_loss += len(data) * nn.CrossEntropyLoss()(output_flat, targets).data
+            hidden = repackage_hidden(hidden)
 
-    return total_loss[0] /len(data_source)
+    return total_loss.item() /len(data_source)
 
 
 def train():
@@ -114,7 +115,7 @@ def train():
         loss.backward()
 
         # `clip_grad_norm` helps prevent the exploding gradient problem in RNNs / LSTMs.
-        torch.nn.utils.clip_grad_norm(model.parameters(), args.clip)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip)
         for p in model.parameters():
             p.data.add_(-lr, p.grad.data)
 

--- a/src/language_models/model.py
+++ b/src/language_models/model.py
@@ -6,7 +6,6 @@
 #
 
 import torch.nn as nn
-from torch.autograd import Variable
 import torch.utils.data.dataloader
 
 
@@ -66,8 +65,8 @@ class RNNModel(nn.Module):
     def init_hidden(self, bsz):
         weight = next(self.parameters()).data
         if self.rnn_type == 'LSTM':
-            return (Variable(weight.new(self.nlayers, bsz, self.nhid).zero_()),
-                    Variable(weight.new(self.nlayers, bsz, self.nhid).zero_()))
+            return (weight.new(self.nlayers, bsz, self.nhid).zero_(),
+                    weight.new(self.nlayers, bsz, self.nhid).zero_())
         else:
-            return Variable(weight.new(self.nlayers, bsz, self.nhid).zero_())
+            return weight.new(self.nlayers, bsz, self.nhid).zero_()
 

--- a/src/language_models/ngram_lstm.py
+++ b/src/language_models/ngram_lstm.py
@@ -122,8 +122,8 @@ def get_batch(source, i, seq_length):
     return data, target
 
 def create_target_mask(test_file, gold_file, index_col):
-    sents = open(test_file, "r").readlines()
-    golds = open(gold_file, "r").readlines()
+    sents = open(test_file, "r", encoding="utf8").readlines()
+    golds = open(gold_file, "r", encoding="utf8").readlines()
     #TODO optimize by initializaing np.array of needed size and doing indexing
     targets = []
     for sent, gold in zip(sents, golds):
@@ -319,7 +319,7 @@ if args.train:
         logging.info('Exiting from training early')
 
     # Load the best saved model.
-    with open(args.save, 'rb') as f:
+    with open(args.save, 'rb', encoding="utf8") as f:
         model = torch.load(f)
 
     # Run on valid data with OOV excluded
@@ -337,7 +337,7 @@ if args.test:
 
     dictionary = Dictionary(args.data)
 
-    with open(args.save, 'rb') as f:
+    with open(args.save, 'rb', encoding="utf8") as f:
         print("Loading the model")
         if args.cuda:
             model = torch.load(f)

--- a/src/language_models/utils.py
+++ b/src/language_models/utils.py
@@ -6,21 +6,21 @@
 #
 
 
-from torch.autograd import Variable
+import torch
 
 def repackage_hidden(h):
-    """Wraps hidden states in new Variables, to detach them from their history."""
-    if type(h) == Variable:
-        return Variable(h.data)
+    """Detaches hidden states from their history."""
+    if isinstance(h, torch.Tensor):
+        return h.detach()
     else:
         return tuple(repackage_hidden(v) for v in h)
 
 
-def get_batch(source, i, seq_length, evaluation=False):
+def get_batch(source, i, seq_length):
     seq_len = min(seq_length, len(source) - 1 - i)
-    data = Variable(source[i:i+seq_len], volatile=evaluation)
+    data = source[i:i+seq_len]
     # predict the sequences shifted by one word
-    target = Variable(source[i+1:i+1+seq_len].view(-1))
+    target = source[i+1:i+1+seq_len].view(-1)
     return data, target
 
 


### PR DESCRIPTION
Update such that the code can also be ran with pytorch versions above 0.3.x and with python3. In particular:
-  Remove uses of Variable in loss computation and repackage_hidden to prevent errors from being raised
- add torch.no_grad() for evaluation, remove deprecated volatile=True
-  remove all uses of Variable
- replace deprecated functions with their new version
- Explicitly specify encoding to avoid problems with python3.