### PR TITLE
Fix bug in the calculation of validation loss

### DIFF
--- a/src/language_models/evaluate_target_word.py
+++ b/src/language_models/evaluate_target_word.py
@@ -49,7 +49,7 @@ def evaluate(data_source, mask):
 
         hidden = repackage_hidden(hidden)
 
-    return total_loss[0] / len(data_source)
+    return total_loss[0] / (len(data_source) - 1)
 
 
 def output_candidates_probs(output_flat, targets, mask):

--- a/src/language_models/main.py
+++ b/src/language_models/main.py
@@ -90,7 +90,7 @@ def evaluate(data_source):
         total_loss += len(data) * nn.CrossEntropyLoss()(output_flat, targets).data
         hidden = repackage_hidden(hidden)
 
-    return total_loss[0] /len(data_source)
+    return total_loss[0] /len(data_source - 1)
 
 
 def train():


### PR DESCRIPTION
The last row of tokens in data-source is never used as input data in the
last batch, but only used as targets. The total_loss should thus not be
divided by len(data_source) but by len(data_source) - 1.