### PR TITLE
Fix pytorch1.0 migration pr

### DIFF
--- a/src/language_models/evaluate_target_word.py
+++ b/src/language_models/evaluate_target_word.py
@@ -18,7 +18,7 @@ import numpy as np
 parser = argparse.ArgumentParser(description='Mask-based evaluation: extracts softmax vectors for specified words')
 
 parser.add_argument('--data', type=str,
-                    help='location of the data corpus')
+                    help='location of the data corpus for LM training')
 parser.add_argument('--checkpoint', type=str,
                     help='model checkpoint to use')
 parser.add_argument('--seed', type=int, default=1111,
@@ -37,30 +37,30 @@ def evaluate(data_source, mask):
     total_loss = 0
 
     hidden = model.init_hidden(eval_batch_size)
-    for i in range(0, data_source.size(0) - 1, seq_len):
-        # keep continuous hidden state across all sentences in the input file
-        data, targets = get_batch(data_source, i, seq_len, evaluation=True)
-        _, targets_mask = get_batch(mask, i, seq_len, evaluation=True)
-        output, hidden = model(data, hidden)
-        output_flat = output.view(-1, vocab_size)
-        total_loss += len(data) * nn.CrossEntropyLoss()(output_flat, targets).data
 
-        output_candidates_probs(output_flat, targets, targets_mask)
+    with torch.no_grad():
+        for i in range(0, data_source.size(0) - 1, seq_len):
+            # keep continuous hidden state across all sentences in the input file
+            data, targets = get_batch(data_source, i, seq_len)
+            _, targets_mask = get_batch(mask, i, seq_len)
+            output, hidden = model(data, hidden)
+            output_flat = output.view(-1, vocab_size)
+            total_loss += len(data) * nn.CrossEntropyLoss()(output_flat, targets)
 
-        hidden = repackage_hidden(hidden)
+            output_candidates_probs(output_flat, targets, targets_mask)
 
-    return total_loss[0] / (len(data_source) - 1)
+            hidden = repackage_hidden(hidden)
+
+    return total_loss.item() / (len(data_source) - 1)
 
 
 def output_candidates_probs(output_flat, targets, mask):
-    log_probs = F.log_softmax(output_flat).data
+    log_probs = F.log_softmax(output_flat, dim=1)
 
     log_probs_np = log_probs.cpu().numpy()
-    subset = mask.data.cpu().numpy().astype(bool)
+    subset = mask.cpu().numpy().astype(bool)
 
-    idx2word = dictionary.idx2word
-
-    for scores, correct_label in zip(log_probs_np[subset], targets.data.cpu().numpy()[subset]):
+    for scores, correct_label in zip(log_probs_np[subset], targets.cpu().numpy()[subset]):
         #print(idx2word[correct_label], scores[correct_label])
         f_output.write("\t".join(str(s) for s in scores) + "\n")
 
@@ -107,8 +107,8 @@ seq_len = 20
 
 dictionary = dictionary_corpus.Dictionary(args.data)
 vocab_size = len(dictionary)
-print("Vocab size", vocab_size)
-print("TESTING")
+#print("Vocab size", vocab_size)
+print("Computing probabilities for target words")
 
 # assuming the mask file contains one number per line indicating the index of the target word
 index_col = 0
@@ -119,6 +119,7 @@ test_data = batchify(dictionary_corpus.tokenize(dictionary, args.path + ".text")
 
 f_output = open(args.path + ".output_" + args.suffix, 'w')
 evaluate(test_data, mask_data)
+print("Probabilities saved to", args.path + ".output_" + args.suffix)
 f_output.close()
 
 

--- a/src/language_models/main.py
+++ b/src/language_models/main.py
@@ -91,7 +91,7 @@ def evaluate(data_source):
             total_loss += len(data) * nn.CrossEntropyLoss()(output_flat, targets).item()
             hidden = repackage_hidden(hidden)
 
-    return total_loss / len(data_source) - 1
+    return total_loss / (len(data_source) - 1)
 
 
 def train():


### PR DESCRIPTION
I moved to pytorch 1.0 the parts of the code that were forgotten to be migrated, in particular, evaluate_target_word.py file. I checked the code both on cpu and gpu so I think this PR fixes it properly. Since I was at it I also made some cosmetic changes.